### PR TITLE
Fix quick start sandbox setup issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ __pycache__/
 dist/
 build/
 .eggs/
+.venv/
+uv.lock
 
 # Traces (generated output, don't commit)
 traces/

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,5 @@ RUN pip install -e ".[mock]" --no-cache-dir
 # Create trace output directory
 RUN mkdir -p /workspace/traces
 
-ENTRYPOINT ["agent-eval"]
+ENTRYPOINT ["claw-eval"]
 CMD ["--help"]

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -14,8 +14,8 @@ RUN pip install -r /tmp/requirements.txt \
         --no-cache-dir \
     && rm /tmp/requirements.txt
 
-# Only copy the sandbox server (not the full agent_eval framework)
-COPY src/agent_eval/sandbox/ /opt/sandbox/
+# Only copy the sandbox server (not the full claw-eval framework)
+COPY src/claw_eval/sandbox/ /opt/sandbox/
 
 # Optional: playwright support (uncomment to enable browser tool)
 # RUN pip install playwright --no-cache-dir && playwright install --with-deps chromium

--- a/requirements-sandbox-server.txt
+++ b/requirements-sandbox-server.txt
@@ -1,4 +1,4 @@
-# Dependencies for the sandbox HTTP server (src/agent_eval/sandbox/server.py).
+# Dependencies for the sandbox HTTP server (src/claw_eval/sandbox/server.py).
 # Used inside agent containers and for local testing.
 #
 #   pip install -r requirements-sandbox-server.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Full dependencies for running agent-eval on the host machine.
+# Full dependencies for running claw-eval on the host machine.
 #
 #   pip install -r requirements.txt
 #

--- a/src/claw_eval/runner/sandbox_runner.py
+++ b/src/claw_eval/runner/sandbox_runner.py
@@ -302,17 +302,28 @@ class SandboxRunner:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _get_mapped_port(self, container) -> int:
-        """Resolve the dynamically-assigned host port for the sandbox service."""
-        container.reload()
+    def _get_mapped_port(self, container, timeout: float = 10.0) -> int:
+        """Resolve the dynamically-assigned host port for the sandbox service.
+
+        Docker may report an empty binding list for a short period right after
+        container creation, so we poll until the mapping is materialized.
+        """
+        deadline = time.monotonic() + timeout
         port_key = f"{self._config.sandbox_port}/tcp"
-        bindings = container.ports.get(port_key)
-        if not bindings:
-            raise RuntimeError(
-                f"No port binding found for {port_key}. "
-                f"Container ports: {container.ports}"
-            )
-        return int(bindings[0]["HostPort"])
+        last_ports = None
+
+        while time.monotonic() < deadline:
+            container.reload()
+            last_ports = container.ports
+            bindings = last_ports.get(port_key)
+            if bindings and bindings[0].get("HostPort"):
+                return int(bindings[0]["HostPort"])
+            time.sleep(0.2)
+
+        raise RuntimeError(
+            f"No port binding found for {port_key} after {timeout:.1f}s. "
+            f"Container ports: {last_ports}"
+        )
 
     def _wait_healthy(self, url: str, timeout: int = 15) -> None:
         """Poll the sandbox /health endpoint until it responds 200."""


### PR DESCRIPTION
This PR fixes a few issues I hit while following the quick start setup.

It ignores local `uv` artifacts, removes some leftover `agent_eval` references, and fixes sandbox startup so Docker port mapping is handled more reliably.