### PR TITLE
fix: validate T57/T58 web_real env config

### DIFF
--- a/tasks/T57_deepseek_logo_identification/task.yaml
+++ b/tasks/T57_deepseek_logo_identification/task.yaml
@@ -20,6 +20,7 @@ services:
     health_check_method: GET
     ready_timeout: 10
     reset_endpoint: http://localhost:9114/web/reset
+    env: {}
 prompt:
   text: Which company does this logo belong to? The image is at fixtures/media/image.jpg
   language: en

--- a/tasks/T58zh_painting_identification/task.yaml
+++ b/tasks/T58zh_painting_identification/task.yaml
@@ -20,6 +20,7 @@ services:
     health_check_method: GET
     ready_timeout: 10
     reset_endpoint: http://localhost:9114/web/reset
+    env: {}
 prompt:
   text: 这件字画是啥？图片路径是 fixtures/media/image.jpg
   language: zh


### PR DESCRIPTION
## What
- replace the empty `env:` mapping in T57 and T58 with `env: {}`
- keep behavior unchanged while making the task definitions valid for pydantic validation

## Why
The empty `env:` entry is parsed as `null` by YAML, but `ServiceDef.env` expects a dictionary. That makes both tasks fail during `TaskDefinition` loading before evaluation actually starts.

## Verification
- ran `PYTHONPATH=src uv run python` to load both task YAML files via `TaskDefinition.from_yaml(...)`
- confirmed both tasks now load successfully