### PR TITLE
Feat/add litellm runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,39 @@ claw-eval batch --config model_configs/claude_opus_46.yaml --sandbox --trials 3 
 # For different tasks, you can follow different config: config_general.yaml/config_multimodal.yaml/config_user_agent.yaml.
 ```
 
+### LiteLLM provider (optional)
+
+By default claw-eval routes models through any OpenAI-compatible endpoint
+(OpenRouter, vLLM, a self-hosted LiteLLM proxy, etc.) using the `openai_compat`
+provider. If you want to skip the proxy and call providers directly through the
+embedded LiteLLM SDK, install the optional extra and set `provider: "litellm"`
+on `model:` in your config.
+
+```bash
+pip install "claw-eval[litellm]"
+```
+
+```yaml
+model:
+  provider: litellm
+  model_id: anthropic/claude-3-5-sonnet-20241022
+  # api_key / base_url are optional — LiteLLM resolves provider keys from
+  # ANTHROPIC_API_KEY / OPENAI_API_KEY / AWS_ACCESS_KEY_ID / AZURE_API_KEY / etc.
+  # Override only for OpenAI-compatible custom endpoints (private LiteLLM proxy,
+  # Azure Foundry deployment).
+  # api_key: sk-ant-...
+  # base_url: https://your-foundry-endpoint/anthropic
+  # Forwarded to every litellm.completion call. drop_params=True (default)
+  # silently strips kwargs the upstream provider doesn't accept.
+  litellm_kwargs:
+    drop_params: true
+    num_retries: 5
+```
+
+This makes any LiteLLM-supported model available without running an extra
+proxy server. See <https://docs.litellm.ai/docs/providers> for the full
+provider list.
+
 ---
 
 ## Roadmap

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ mock = ["fastapi>=0.115", "uvicorn>=0.30", "pypdf", "trafilatura>=1.8", "request
 web = ["trafilatura>=1.8", "requests>=2.28"]
 sandbox = ["docker>=7.0"]
 dev = ["pytest>=8.0"]
+# Embedded LiteLLM provider: one provider, 100+ upstream backends.
+litellm = ["litellm>=1.60,<1.85"]
 
 [project.scripts]
 claw-eval = "claw_eval.cli:main"

--- a/src/claw_eval/cli.py
+++ b/src/claw_eval/cli.py
@@ -52,6 +52,25 @@ def _make_trace_dir(base_dir: str | Path, model_id: str) -> Path:
     return trace_dir
 
 
+def _make_model_provider(cfg, model_id, api_key=None, base_url=None):
+    """Build a provider for the run, honoring CLI / programmatic overrides.
+
+    Dispatches on ``cfg.model.provider`` ("openai_compat" default, "litellm"
+    optional). Returns an OpenAICompatProvider or LiteLLMProvider; both expose
+    the same chat() interface so the rest of the runner is provider-agnostic.
+    """
+    from .runner.providers import make_provider
+
+    overridden = cfg.model.model_copy(
+        update={
+            "model_id": model_id,
+            "api_key": api_key or cfg.model.api_key,
+            "base_url": base_url or cfg.model.base_url,
+        }
+    )
+    return make_provider(overridden)
+
+
 def _make_judge(cfg, args):
     """Create an LLMJudge instance if enabled, or None."""
     if getattr(args, "no_judge", False):
@@ -324,7 +343,6 @@ def cmd_run(args: argparse.Namespace) -> None:
     from .models.scoring import compute_pass_at_k, compute_pass_hat_k, compute_task_score, is_pass
     from .models.task import TaskDefinition
     from .runner.loop import run_task
-    from .runner.providers.openai_compat import OpenAICompatProvider
     from .trace.reader import load_trace
 
     cfg = load_config(args.config)
@@ -351,14 +369,7 @@ def cmd_run(args: argparse.Namespace) -> None:
 
         sandbox_image = getattr(args, "sandbox_image", None) or cfg.sandbox.image
         runner = SandboxRunner(cfg.sandbox, image=sandbox_image)
-        provider = OpenAICompatProvider(
-            model_id=model_id,
-            api_key=args.api_key or cfg.model.api_key,
-            base_url=args.base_url or cfg.model.base_url,
-            extra_body=cfg.model.extra_body,
-            temperature=cfg.model.temperature,
-            reasoning_effort=cfg.model.reasoning_effort,
-        )
+        provider = _make_model_provider(cfg, model_id, args.api_key, args.base_url)
         judge = _make_judge(cfg, args)
         trials = args.trials or 1
         trial_scores: list[float] = []
@@ -476,14 +487,7 @@ def cmd_run(args: argparse.Namespace) -> None:
         return
 
     # ---- Normal (local) mode ----
-    provider = OpenAICompatProvider(
-        model_id=model_id,
-        api_key=args.api_key or cfg.model.api_key,
-        base_url=args.base_url or cfg.model.base_url,
-        extra_body=cfg.model.extra_body,
-        temperature=cfg.model.temperature,
-        reasoning_effort=cfg.model.reasoning_effort,
-    )
+    provider = _make_model_provider(cfg, model_id, args.api_key, args.base_url)
 
     judge = _make_judge(cfg, args)
     sandbox_tools = getattr(args, "sandbox_tools", False)
@@ -582,7 +586,6 @@ def cmd_run_inner(args: argparse.Namespace) -> None:
     from .models.scoring import compute_task_score, is_pass
     from .models.task import TaskDefinition
     from .runner.loop import run_task
-    from .runner.providers.openai_compat import OpenAICompatProvider
     from .runner.services import ServiceManager
     from .trace.reader import load_trace
 
@@ -593,14 +596,18 @@ def cmd_run_inner(args: argparse.Namespace) -> None:
     tasks_dir = _resolve_tasks_dir(task_yaml)
 
     model_id = args.model or cfg.model.model_id
-    provider = OpenAICompatProvider(
-        model_id=model_id,
-        api_key=args.api_key or cfg.model.api_key or os.environ.get("OPENAI_API_KEY"),
-        base_url=args.base_url or cfg.model.base_url,
-        extra_body=cfg.model.extra_body,
-        temperature=cfg.model.temperature,
-        reasoning_effort=cfg.model.reasoning_effort,
-    )
+    # Last-resort fallback to OPENAI_API_KEY when api_key is unset on the
+    # openai_compat path; LiteLLM resolves provider keys per-call so this
+    # only matters for the OpenAI-compatible path.
+    if (
+        cfg.model.provider == "openai_compat"
+        and not (args.api_key or cfg.model.api_key)
+        and os.environ.get("OPENAI_API_KEY")
+    ):
+        cfg = cfg.model_copy(
+            update={"model": cfg.model.model_copy(update={"api_key": os.environ["OPENAI_API_KEY"]})}
+        )
+    provider = _make_model_provider(cfg, model_id, args.api_key, args.base_url)
 
     sandbox_tools = getattr(args, "sandbox_tools", False)
     # _run-inner receives the final trace dir from the caller (e.g. submit script).
@@ -795,7 +802,6 @@ def _run_single_task(
     from .models.scoring import compute_pass_at_k, compute_pass_hat_k, compute_task_score, is_pass
     from .models.task import TaskDefinition
     from .runner.loop import run_task
-    from .runner.providers.openai_compat import OpenAICompatProvider
     from .runner.services import ServiceManager
     from .trace.reader import load_trace
 
@@ -807,13 +813,11 @@ def _run_single_task(
         task.apply_port_offset(port_offset)
 
     cfg = load_config(config_path)
-    provider = OpenAICompatProvider(
-        model_id=model or cfg.model.model_id,
-        api_key=api_key or cfg.model.api_key,
-        base_url=base_url or cfg.model.base_url,
-        extra_body=cfg.model.extra_body,
-        temperature=cfg.model.temperature,
-        reasoning_effort=cfg.model.reasoning_effort,
+    provider = _make_model_provider(
+        cfg,
+        model or cfg.model.model_id,
+        api_key=api_key,
+        base_url=base_url,
     )
 
     # Build judge if needed

--- a/src/claw_eval/config.py
+++ b/src/claw_eval/config.py
@@ -59,9 +59,6 @@ class JudgeConfig(BaseModel):
     base_url: str = "https://openrouter.ai/api/v1"
     model_id: str = "google/gemini-3-flash-preview"
     enabled: bool = True
-    # Same provider switch as ModelConfig; defaults to OpenRouter via openai_compat.
-    provider: str = "openai_compat"
-    litellm_kwargs: dict | None = None
 
 
 class DefaultsConfig(BaseModel):

--- a/src/claw_eval/config.py
+++ b/src/claw_eval/config.py
@@ -48,6 +48,10 @@ class ModelConfig(BaseModel):
     reasoning_effort: str | None = None
     context_window: int = 262144
     temperature: float | None = 0.0  # None = don't send temperature param
+    # "openai_compat" (default, uses openai SDK against any OpenAI-compatible
+    # base_url) or "litellm" (embedded LiteLLM SDK; no proxy server).
+    provider: str = "openai_compat"
+    litellm_kwargs: dict | None = None
 
 
 class JudgeConfig(BaseModel):
@@ -55,6 +59,9 @@ class JudgeConfig(BaseModel):
     base_url: str = "https://openrouter.ai/api/v1"
     model_id: str = "google/gemini-3-flash-preview"
     enabled: bool = True
+    # Same provider switch as ModelConfig; defaults to OpenRouter via openai_compat.
+    provider: str = "openai_compat"
+    litellm_kwargs: dict | None = None
 
 
 class DefaultsConfig(BaseModel):

--- a/src/claw_eval/runner/providers/__init__.py
+++ b/src/claw_eval/runner/providers/__init__.py
@@ -1,5 +1,34 @@
 """Model providers."""
 
+from __future__ import annotations
+
 from .openai_compat import OpenAICompatProvider
 
-__all__ = ["OpenAICompatProvider"]
+__all__ = ["OpenAICompatProvider", "make_provider"]
+
+
+def make_provider(model_cfg):
+    """Factory: build the right provider for a ModelConfig.
+
+    Dispatches on ``model_cfg.provider`` ("openai_compat" default,
+    "litellm" optional). Unknown providers raise so config typos surface
+    immediately rather than silently falling back.
+    """
+    common = {
+        "model_id": model_cfg.model_id,
+        "api_key": model_cfg.api_key,
+        "base_url": model_cfg.base_url,
+        "extra_body": model_cfg.extra_body,
+        "temperature": model_cfg.temperature,
+        "reasoning_effort": model_cfg.reasoning_effort,
+    }
+
+    if model_cfg.provider == "litellm":
+        from .litellm import LiteLLMProvider
+
+        return LiteLLMProvider(**common, litellm_kwargs=model_cfg.litellm_kwargs)
+    if model_cfg.provider == "openai_compat":
+        return OpenAICompatProvider(**common)
+    raise ValueError(
+        f"Unknown provider {model_cfg.provider!r} (expected 'openai_compat' or 'litellm')."
+    )

--- a/src/claw_eval/runner/providers/__init__.py
+++ b/src/claw_eval/runner/providers/__init__.py
@@ -29,6 +29,4 @@ def make_provider(model_cfg):
         return LiteLLMProvider(**common, litellm_kwargs=model_cfg.litellm_kwargs)
     if model_cfg.provider == "openai_compat":
         return OpenAICompatProvider(**common)
-    raise ValueError(
-        f"Unknown provider {model_cfg.provider!r} (expected 'openai_compat' or 'litellm')."
-    )
+    raise ValueError(f"Unknown provider {model_cfg.provider!r} (expected 'openai_compat' or 'litellm').")

--- a/src/claw_eval/runner/providers/litellm.py
+++ b/src/claw_eval/runner/providers/litellm.py
@@ -15,16 +15,19 @@ environment variables (``ANTHROPIC_API_KEY``, ``OPENAI_API_KEY``,
 (``frequency_penalty`` / ``presence_penalty`` on Anthropic, Gemini, Bedrock;
 ``response_format`` on Bedrock; etc.) are silently dropped instead of raising
 ``UnsupportedParamsError``.
+
+The class subclasses ``OpenAICompatProvider`` and overrides only the two
+methods that do the network call (``_call_without_stream`` and
+``_call_with_stream``); the rest of the chat loop, multimodal check,
+retry-on-error logic, streaming-fallback, and response parsing is inherited
+unchanged.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-from ...models.message import Message
-from ...models.tool import ToolSpec
-from ...models.trace import TokenUsage
-from .openai_compat import OpenAICompatProvider, _message_to_openai, _tool_spec_to_openai
+from .openai_compat import OpenAICompatProvider
 
 
 class LiteLLMProvider(OpenAICompatProvider):
@@ -49,9 +52,9 @@ class LiteLLMProvider(OpenAICompatProvider):
                 '`pip install "litellm>=1.60,<1.85"`.'
             ) from exc
 
-        # We deliberately skip OpenAICompatProvider.__init__ because that one
-        # builds an `openai.OpenAI` client we never use. Set the same
-        # attributes its inherited methods (notably _parse_response) read.
+        # Skip OpenAICompatProvider.__init__ (we don't need its openai.OpenAI
+        # client). Set every attribute the inherited chat()/_parse_response
+        # methods read.
         self.model_id = model_id
         self.api_key = api_key
         self.base_url = base_url
@@ -64,48 +67,121 @@ class LiteLLMProvider(OpenAICompatProvider):
             merged.update(litellm_kwargs)
         self.litellm_kwargs = merged
 
-    def chat(
-        self,
-        messages: list[Message],
-        tools: list[ToolSpec] | None = None,
-    ) -> tuple[Message, TokenUsage]:
-        """Send messages to the model via litellm.completion and return parsed response."""
+    def _full_kwargs(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+        """Add credentials and litellm-specific kwargs onto the request."""
+        full = dict(kwargs)
+        if self.api_key:
+            full["api_key"] = self.api_key
+        if self.base_url:
+            full["api_base"] = self.base_url
+        # litellm_kwargs come last so users can override anything in `kwargs`
+        # (drop_params, num_retries, custom timeouts, etc.).
+        full.update(self.litellm_kwargs)
+        return full
+
+    def _call_without_stream(self, kwargs: dict[str, Any]) -> Any:
+        """Non-streaming completion via litellm.completion()."""
         import litellm
 
-        oai_messages: list[dict[str, Any]] = []
-        for msg in messages:
-            converted = _message_to_openai(msg)
-            if isinstance(converted, list):
-                oai_messages.extend(converted)
-            else:
-                oai_messages.append(converted)
+        return litellm.completion(**self._full_kwargs(kwargs))
 
-        kwargs: dict[str, Any] = {
-            "model": self.model_id,
-            "messages": oai_messages,
-        }
-        if self.temperature is not None:
-            kwargs["temperature"] = self.temperature
-        if self.extra_body:
-            # litellm forwards extra_body to the underlying provider, same as
-            # the openai SDK path.
-            kwargs["extra_body"] = dict(self.extra_body)
-        if self.reasoning_effort:
-            kwargs["reasoning_effort"] = self.reasoning_effort
-        if tools:
-            kwargs["tools"] = [_tool_spec_to_openai(t) for t in tools]
+    def _call_with_stream(self, kwargs: dict[str, Any]) -> Any:
+        """Streaming completion via litellm.completion(stream=True).
 
-        # Provider-level credentials override per-request env-var resolution
-        # so users with a single shared key (private LiteLLM proxy / custom
-        # OpenAI-compatible endpoint) can configure once.
-        if self.api_key:
-            kwargs["api_key"] = self.api_key
-        if self.base_url:
-            kwargs["api_base"] = self.base_url
+        Mirrors the chunk-assembly pattern in OpenAICompatProvider so the
+        inherited ``_parse_response`` sees the same duck-typed object shape.
+        """
+        import litellm
 
-        # litellm_kwargs (drop_params, num_retries, etc.) come last so users
-        # can override anything above by setting it in litellm_kwargs.
-        kwargs.update(self.litellm_kwargs)
+        stream_kwargs: dict[str, Any] = {"stream": True}
+        # stream_options is OpenAI-specific; Anthropic / Claude endpoints
+        # reject it. LiteLLM normalizes the response shape either way.
+        model_lower = kwargs.get("model", "").lower()
+        is_anthropic = any(s in model_lower for s in ("claude", "anthropic"))
+        if not is_anthropic:
+            stream_kwargs["stream_options"] = {"include_usage": True}
 
-        response = litellm.completion(**kwargs)
-        return self._parse_response(response)
+        full = self._full_kwargs({**kwargs, **stream_kwargs})
+        stream = litellm.completion(**full)
+
+        reasoning_parts: list[str] = []
+        content_parts: list[str] = []
+        tool_calls_by_index: dict[int, dict[str, Any]] = {}
+        usage_info = None
+        has_any_choice = False
+
+        for chunk in stream:
+            if getattr(chunk, "usage", None):
+                usage_info = chunk.usage
+            choices = getattr(chunk, "choices", None) or []
+            if not choices:
+                continue
+            has_any_choice = True
+            delta = choices[0].delta
+
+            rc = getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None)
+            if rc:
+                reasoning_parts.append(rc)
+
+            if delta.content:
+                content_parts.append(delta.content)
+
+            if delta.tool_calls:
+                for tc_delta in delta.tool_calls:
+                    idx = tc_delta.index
+                    if idx not in tool_calls_by_index:
+                        tool_calls_by_index[idx] = {"id": "", "name": "", "arguments": ""}
+                    if tc_delta.id:
+                        tool_calls_by_index[idx]["id"] = tc_delta.id
+                    if tc_delta.function:
+                        if tc_delta.function.name:
+                            tool_calls_by_index[idx]["name"] = tc_delta.function.name
+                        if tc_delta.function.arguments:
+                            tool_calls_by_index[idx]["arguments"] += tc_delta.function.arguments
+
+        if not has_any_choice:
+            raise RuntimeError("Model returned empty choices (choices=None or [])")
+
+        class _Msg:
+            pass
+
+        msg = _Msg()
+        msg.content = "".join(content_parts) if content_parts else None
+        msg.reasoning_content = "".join(reasoning_parts) if reasoning_parts else None
+
+        if tool_calls_by_index:
+            assembled = []
+            for idx in sorted(tool_calls_by_index):
+                tc = tool_calls_by_index[idx]
+
+                class _Fn:
+                    pass
+
+                fn = _Fn()
+                fn.name = tc["name"]
+                fn.arguments = tc["arguments"]
+
+                class _TC:
+                    pass
+
+                t = _TC()
+                t.id = tc["id"]
+                t.function = fn
+                assembled.append(t)
+            msg.tool_calls = assembled
+        else:
+            msg.tool_calls = None
+
+        class _Choice:
+            pass
+
+        choice = _Choice()
+        choice.message = msg
+
+        class _Resp:
+            pass
+
+        resp = _Resp()
+        resp.choices = [choice]
+        resp.usage = usage_info
+        return resp

--- a/src/claw_eval/runner/providers/litellm.py
+++ b/src/claw_eval/runner/providers/litellm.py
@@ -1,37 +1,19 @@
-"""LiteLLM AI Gateway provider.
-
-Routes every chat completion through ``litellm.completion`` so a single
-provider can run claw-eval against OpenAI, Anthropic, Vertex AI, Bedrock,
-Azure, Cohere, Mistral, Groq, Ollama, and 90+ other backends without
-configuring a separate OpenAI-compatible proxy server (OpenRouter, vLLM,
-LiteLLM proxy, etc.). Pick the model with the standard LiteLLM
-provider-prefixed name ("anthropic/claude-3-5-sonnet-20241022",
-"vertex_ai/gemini-1.5-pro", "bedrock/anthropic.claude-3-haiku-20240307-v1:0",
-"azure/gpt-4o", ...) and credentials are resolved from provider-specific
-environment variables (``ANTHROPIC_API_KEY``, ``OPENAI_API_KEY``,
-``AWS_ACCESS_KEY_ID``, ...) by default.
-
-``drop_params=True`` is on by default so kwargs that some providers reject
-(``frequency_penalty`` / ``presence_penalty`` on Anthropic, Gemini, Bedrock;
-``response_format`` on Bedrock; etc.) are silently dropped instead of raising
-``UnsupportedParamsError``.
-
-The class subclasses ``OpenAICompatProvider`` and overrides only the two
-methods that do the network call (``_call_without_stream`` and
-``_call_with_stream``); the rest of the chat loop, multimodal check,
-retry-on-error logic, streaming-fallback, and response parsing is inherited
-unchanged.
-"""
+"""LiteLLM provider: route chat completions through litellm.completion()."""
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
-from .openai_compat import OpenAICompatProvider
+from ...models.content import TextBlock, ToolUseBlock
+from ...models.message import Message
+from ...models.tool import ToolSpec
+from ...models.trace import TokenUsage
+from .openai_compat import _extract_text_tool_calls, _message_to_openai, _tool_spec_to_openai
 
 
-class LiteLLMProvider(OpenAICompatProvider):
-    """LiteLLM-routed provider; embedded SDK, no proxy server."""
+class LiteLLMProvider:
+    """LiteLLM SDK in-process; no proxy server."""
 
     def __init__(
         self,
@@ -46,15 +28,8 @@ class LiteLLMProvider(OpenAICompatProvider):
         try:
             import litellm  # noqa: F401
         except ImportError as exc:
-            raise ImportError(
-                "litellm is required for LiteLLMProvider. "
-                'Install via `pip install "claw-eval[litellm]"` or '
-                '`pip install "litellm>=1.60,<1.85"`.'
-            ) from exc
+            raise ImportError('litellm is required. Install via `pip install "claw-eval[litellm]"`.') from exc
 
-        # Skip OpenAICompatProvider.__init__ (we don't need its openai.OpenAI
-        # client). Set every attribute the inherited chat()/_parse_response
-        # methods read.
         self.model_id = model_id
         self.api_key = api_key
         self.base_url = base_url
@@ -67,121 +42,105 @@ class LiteLLMProvider(OpenAICompatProvider):
             merged.update(litellm_kwargs)
         self.litellm_kwargs = merged
 
-    def _full_kwargs(self, kwargs: dict[str, Any]) -> dict[str, Any]:
-        """Add credentials and litellm-specific kwargs onto the request."""
-        full = dict(kwargs)
+    def chat(
+        self,
+        messages: list[Message],
+        tools: list[ToolSpec] | None = None,
+    ) -> tuple[Message, TokenUsage]:
+        import litellm
+
+        oai_messages: list[dict[str, Any]] = []
+        for msg in messages:
+            converted = _message_to_openai(msg)
+            if isinstance(converted, list):
+                oai_messages.extend(converted)
+            else:
+                oai_messages.append(converted)
+
+        kwargs: dict[str, Any] = {
+            "model": self.model_id,
+            "messages": oai_messages,
+        }
+        if self.temperature is not None:
+            kwargs["temperature"] = self.temperature
+        if self.extra_body:
+            kwargs["extra_body"] = dict(self.extra_body)
+        if self.reasoning_effort:
+            kwargs["reasoning_effort"] = self.reasoning_effort
+        if tools:
+            kwargs["tools"] = [_tool_spec_to_openai(t) for t in tools]
         if self.api_key:
-            full["api_key"] = self.api_key
+            kwargs["api_key"] = self.api_key
         if self.base_url:
-            full["api_base"] = self.base_url
-        # litellm_kwargs come last so users can override anything in `kwargs`
-        # (drop_params, num_retries, custom timeouts, etc.).
-        full.update(self.litellm_kwargs)
-        return full
+            kwargs["api_base"] = self.base_url
 
-    def _call_without_stream(self, kwargs: dict[str, Any]) -> Any:
-        """Non-streaming completion via litellm.completion()."""
-        import litellm
+        # litellm_kwargs (drop_params, num_retries, custom timeouts, ...) come
+        # last so users can override anything above by setting it in config.
+        kwargs.update(self.litellm_kwargs)
 
-        return litellm.completion(**self._full_kwargs(kwargs))
+        response = litellm.completion(**kwargs)
+        return _parse_response(response)
 
-    def _call_with_stream(self, kwargs: dict[str, Any]) -> Any:
-        """Streaming completion via litellm.completion(stream=True).
 
-        Mirrors the chunk-assembly pattern in OpenAICompatProvider so the
-        inherited ``_parse_response`` sees the same duck-typed object shape.
-        """
-        import litellm
+def _parse_response(response: Any) -> tuple[Message, TokenUsage]:
+    """Convert a litellm.completion response into Message + TokenUsage.
 
-        stream_kwargs: dict[str, Any] = {"stream": True}
-        # stream_options is OpenAI-specific; Anthropic / Claude endpoints
-        # reject it. LiteLLM normalizes the response shape either way.
-        model_lower = kwargs.get("model", "").lower()
-        is_anthropic = any(s in model_lower for s in ("claude", "anthropic"))
-        if not is_anthropic:
-            stream_kwargs["stream_options"] = {"include_usage": True}
+    Mirrors OpenAICompatProvider._parse_response. Kept as a sibling function
+    rather than reusing the method by inheritance because LiteLLMProvider is
+    a standalone class.
+    """
+    if not response.choices:
+        raise RuntimeError("Model returned empty choices (choices=None or [])")
+    choice = response.choices[0]
 
-        full = self._full_kwargs({**kwargs, **stream_kwargs})
-        stream = litellm.completion(**full)
+    content_blocks: list[Any] = []
+    if choice.message.content:
+        if isinstance(choice.message.content, str):
+            content_blocks.append(TextBlock(text=choice.message.content))
+        elif isinstance(choice.message.content, list):
+            text_chunks = []
+            for part in choice.message.content:
+                if isinstance(part, dict):
+                    if part.get("type") == "text":
+                        text = part.get("text")
+                        if isinstance(text, str):
+                            text_chunks.append(text)
+                    continue
+                if getattr(part, "type", None) == "text":
+                    text = getattr(part, "text", None)
+                    if isinstance(text, str):
+                        text_chunks.append(text)
+            if text_chunks:
+                content_blocks.append(TextBlock(text="\n".join(text_chunks)))
 
-        reasoning_parts: list[str] = []
-        content_parts: list[str] = []
-        tool_calls_by_index: dict[int, dict[str, Any]] = {}
-        usage_info = None
-        has_any_choice = False
+    if choice.message.tool_calls:
+        for tc in choice.message.tool_calls:
+            try:
+                args = json.loads(tc.function.arguments)
+            except json.JSONDecodeError:
+                args = {}
+            content_blocks.append(ToolUseBlock(id=tc.id, name=tc.function.name, input=args))
+    else:
+        # Some providers emit pseudo tool markup in plain text.
+        text_blocks = [b for b in content_blocks if b.type == "text"]
+        if text_blocks:
+            merged = "\n".join(b.text for b in text_blocks)
+            cleaned, fallback_tools = _extract_text_tool_calls(merged)
+            if fallback_tools:
+                content_blocks = []
+                if cleaned:
+                    content_blocks.append(TextBlock(text=cleaned))
+                content_blocks.extend(fallback_tools)
 
-        for chunk in stream:
-            if getattr(chunk, "usage", None):
-                usage_info = chunk.usage
-            choices = getattr(chunk, "choices", None) or []
-            if not choices:
-                continue
-            has_any_choice = True
-            delta = choices[0].delta
+    usage = TokenUsage()
+    if response.usage:
+        usage = TokenUsage(
+            input_tokens=response.usage.prompt_tokens,
+            output_tokens=response.usage.completion_tokens,
+        )
 
-            rc = getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None)
-            if rc:
-                reasoning_parts.append(rc)
-
-            if delta.content:
-                content_parts.append(delta.content)
-
-            if delta.tool_calls:
-                for tc_delta in delta.tool_calls:
-                    idx = tc_delta.index
-                    if idx not in tool_calls_by_index:
-                        tool_calls_by_index[idx] = {"id": "", "name": "", "arguments": ""}
-                    if tc_delta.id:
-                        tool_calls_by_index[idx]["id"] = tc_delta.id
-                    if tc_delta.function:
-                        if tc_delta.function.name:
-                            tool_calls_by_index[idx]["name"] = tc_delta.function.name
-                        if tc_delta.function.arguments:
-                            tool_calls_by_index[idx]["arguments"] += tc_delta.function.arguments
-
-        if not has_any_choice:
-            raise RuntimeError("Model returned empty choices (choices=None or [])")
-
-        class _Msg:
-            pass
-
-        msg = _Msg()
-        msg.content = "".join(content_parts) if content_parts else None
-        msg.reasoning_content = "".join(reasoning_parts) if reasoning_parts else None
-
-        if tool_calls_by_index:
-            assembled = []
-            for idx in sorted(tool_calls_by_index):
-                tc = tool_calls_by_index[idx]
-
-                class _Fn:
-                    pass
-
-                fn = _Fn()
-                fn.name = tc["name"]
-                fn.arguments = tc["arguments"]
-
-                class _TC:
-                    pass
-
-                t = _TC()
-                t.id = tc["id"]
-                t.function = fn
-                assembled.append(t)
-            msg.tool_calls = assembled
-        else:
-            msg.tool_calls = None
-
-        class _Choice:
-            pass
-
-        choice = _Choice()
-        choice.message = msg
-
-        class _Resp:
-            pass
-
-        resp = _Resp()
-        resp.choices = [choice]
-        resp.usage = usage_info
-        return resp
+    reasoning = getattr(choice.message, "reasoning_content", None) or getattr(choice.message, "reasoning", None)
+    return (
+        Message(role="assistant", content=content_blocks, reasoning_content=reasoning),
+        usage,
+    )

--- a/src/claw_eval/runner/providers/litellm.py
+++ b/src/claw_eval/runner/providers/litellm.py
@@ -1,0 +1,111 @@
+"""LiteLLM AI Gateway provider.
+
+Routes every chat completion through ``litellm.completion`` so a single
+provider can run claw-eval against OpenAI, Anthropic, Vertex AI, Bedrock,
+Azure, Cohere, Mistral, Groq, Ollama, and 90+ other backends without
+configuring a separate OpenAI-compatible proxy server (OpenRouter, vLLM,
+LiteLLM proxy, etc.). Pick the model with the standard LiteLLM
+provider-prefixed name ("anthropic/claude-3-5-sonnet-20241022",
+"vertex_ai/gemini-1.5-pro", "bedrock/anthropic.claude-3-haiku-20240307-v1:0",
+"azure/gpt-4o", ...) and credentials are resolved from provider-specific
+environment variables (``ANTHROPIC_API_KEY``, ``OPENAI_API_KEY``,
+``AWS_ACCESS_KEY_ID``, ...) by default.
+
+``drop_params=True`` is on by default so kwargs that some providers reject
+(``frequency_penalty`` / ``presence_penalty`` on Anthropic, Gemini, Bedrock;
+``response_format`` on Bedrock; etc.) are silently dropped instead of raising
+``UnsupportedParamsError``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...models.message import Message
+from ...models.tool import ToolSpec
+from ...models.trace import TokenUsage
+from .openai_compat import OpenAICompatProvider, _message_to_openai, _tool_spec_to_openai
+
+
+class LiteLLMProvider(OpenAICompatProvider):
+    """LiteLLM-routed provider; embedded SDK, no proxy server."""
+
+    def __init__(
+        self,
+        model_id: str = "anthropic/claude-3-5-sonnet-20241022",
+        api_key: str | None = None,
+        base_url: str | None = None,
+        extra_body: dict | None = None,
+        temperature: float | None = 0.0,
+        reasoning_effort: str | None = None,
+        litellm_kwargs: dict | None = None,
+    ) -> None:
+        try:
+            import litellm  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "litellm is required for LiteLLMProvider. "
+                'Install via `pip install "claw-eval[litellm]"` or '
+                '`pip install "litellm>=1.60,<1.85"`.'
+            ) from exc
+
+        # We deliberately skip OpenAICompatProvider.__init__ because that one
+        # builds an `openai.OpenAI` client we never use. Set the same
+        # attributes its inherited methods (notably _parse_response) read.
+        self.model_id = model_id
+        self.api_key = api_key
+        self.base_url = base_url
+        self.extra_body = extra_body or {}
+        self.temperature = temperature
+        self.reasoning_effort = reasoning_effort
+
+        merged: dict[str, Any] = {"drop_params": True, "num_retries": 5}
+        if litellm_kwargs:
+            merged.update(litellm_kwargs)
+        self.litellm_kwargs = merged
+
+    def chat(
+        self,
+        messages: list[Message],
+        tools: list[ToolSpec] | None = None,
+    ) -> tuple[Message, TokenUsage]:
+        """Send messages to the model via litellm.completion and return parsed response."""
+        import litellm
+
+        oai_messages: list[dict[str, Any]] = []
+        for msg in messages:
+            converted = _message_to_openai(msg)
+            if isinstance(converted, list):
+                oai_messages.extend(converted)
+            else:
+                oai_messages.append(converted)
+
+        kwargs: dict[str, Any] = {
+            "model": self.model_id,
+            "messages": oai_messages,
+        }
+        if self.temperature is not None:
+            kwargs["temperature"] = self.temperature
+        if self.extra_body:
+            # litellm forwards extra_body to the underlying provider, same as
+            # the openai SDK path.
+            kwargs["extra_body"] = dict(self.extra_body)
+        if self.reasoning_effort:
+            kwargs["reasoning_effort"] = self.reasoning_effort
+        if tools:
+            kwargs["tools"] = [_tool_spec_to_openai(t) for t in tools]
+
+        # Provider-level credentials override per-request env-var resolution
+        # so users with a single shared key (private LiteLLM proxy / custom
+        # OpenAI-compatible endpoint) can configure once.
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        if self.base_url:
+            kwargs["api_base"] = self.base_url
+
+        # litellm_kwargs (drop_params, num_retries, etc.) come last so users
+        # can override anything above by setting it in litellm_kwargs.
+        kwargs.update(self.litellm_kwargs)
+
+        response = litellm.completion(**kwargs)
+        return self._parse_response(response)

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -11,12 +11,11 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from claw_eval.config import ModelConfig
-from claw_eval.models.content import TextBlock, ToolUseBlock
+from claw_eval.models.content import TextBlock
 from claw_eval.models.message import Message
 from claw_eval.models.tool import ToolSpec
 from claw_eval.runner.providers import OpenAICompatProvider, make_provider
 from claw_eval.runner.providers.litellm import LiteLLMProvider
-
 
 # ---------------------------------------------------------------------------
 # Mocked litellm.completion responses (OpenAI shape)
@@ -107,8 +106,8 @@ class TestLiteLLMProviderInit(unittest.TestCase):
         self.assertEqual(p.litellm_kwargs.get("timeout"), 120)
         self.assertIs(p.litellm_kwargs.get("drop_params"), True)
 
-    def test_skips_openai_client_setup(self):
-        # Parent OpenAICompatProvider sets self.client; we deliberately don't.
+    def test_no_client_attribute(self):
+        # Standalone provider, no openai.OpenAI client to construct.
         p = LiteLLMProvider(model_id="openai/gpt-4o")
         self.assertFalse(hasattr(p, "client"))
 
@@ -197,9 +196,7 @@ class TestChatRouting(unittest.TestCase):
         p = LiteLLMProvider(model_id="anthropic/claude-3-5-sonnet-20241022")
         tool_call = SimpleNamespace(
             id="call_123",
-            function=SimpleNamespace(
-                name="get_weather", arguments='{"city":"Tokyo"}'
-            ),
+            function=SimpleNamespace(name="get_weather", arguments='{"city":"Tokyo"}'),
         )
 
         with patch(

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -1,0 +1,218 @@
+"""Unit tests for the LiteLLM provider and the make_provider factory.
+
+Tests run without external dependencies by mocking ``litellm.completion``.
+Live integration is exercised via a separate scratch script.
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from claw_eval.config import ModelConfig
+from claw_eval.models.content import TextBlock, ToolUseBlock
+from claw_eval.models.message import Message
+from claw_eval.models.tool import ToolSpec
+from claw_eval.runner.providers import OpenAICompatProvider, make_provider
+from claw_eval.runner.providers.litellm import LiteLLMProvider
+
+
+# ---------------------------------------------------------------------------
+# Mocked litellm.completion responses (OpenAI shape)
+# ---------------------------------------------------------------------------
+
+
+def _completion_response(content, tool_calls=None, prompt_tokens=10, completion_tokens=5):
+    msg = SimpleNamespace(
+        content=content,
+        tool_calls=tool_calls,
+        reasoning_content=None,
+        reasoning=None,
+    )
+    choice = SimpleNamespace(message=msg, finish_reason="stop")
+    usage = SimpleNamespace(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+    )
+    return SimpleNamespace(choices=[choice], usage=usage)
+
+
+def _user(text):
+    return Message(role="user", content=[TextBlock(text=text)])
+
+
+# ---------------------------------------------------------------------------
+# Factory dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestMakeProvider(unittest.TestCase):
+    def test_default_is_openai_compat(self):
+        cfg = ModelConfig(model_id="openai/gpt-4o-mini")
+        self.assertEqual(cfg.provider, "openai_compat")
+        provider = make_provider(cfg)
+        self.assertIsInstance(provider, OpenAICompatProvider)
+        self.assertNotIsInstance(provider, LiteLLMProvider)
+
+    def test_litellm_dispatch(self):
+        cfg = ModelConfig(
+            provider="litellm",
+            model_id="anthropic/claude-3-5-sonnet-20241022",
+        )
+        provider = make_provider(cfg)
+        self.assertIsInstance(provider, LiteLLMProvider)
+        self.assertEqual(provider.model_id, "anthropic/claude-3-5-sonnet-20241022")
+
+    def test_unknown_provider_raises(self):
+        cfg = ModelConfig(provider="bogus")
+        with self.assertRaisesRegex(ValueError, "Unknown provider"):
+            make_provider(cfg)
+
+    def test_litellm_kwargs_pass_through(self):
+        cfg = ModelConfig(
+            provider="litellm",
+            model_id="openai/gpt-4o-mini",
+            litellm_kwargs={"num_retries": 7},
+        )
+        provider = make_provider(cfg)
+        self.assertEqual(provider.litellm_kwargs.get("num_retries"), 7)
+        # default still preserved
+        self.assertIs(provider.litellm_kwargs.get("drop_params"), True)
+
+
+# ---------------------------------------------------------------------------
+# LiteLLMProvider initialization
+# ---------------------------------------------------------------------------
+
+
+class TestLiteLLMProviderInit(unittest.TestCase):
+    def test_drop_params_default_on(self):
+        p = LiteLLMProvider(model_id="openai/gpt-4o")
+        self.assertIs(p.litellm_kwargs.get("drop_params"), True)
+
+    def test_drop_params_can_be_disabled(self):
+        p = LiteLLMProvider(
+            model_id="openai/gpt-4o",
+            litellm_kwargs={"drop_params": False},
+        )
+        self.assertIs(p.litellm_kwargs.get("drop_params"), False)
+
+    def test_user_kwargs_merge_with_default(self):
+        p = LiteLLMProvider(
+            model_id="openai/gpt-4o",
+            litellm_kwargs={"timeout": 120},
+        )
+        self.assertEqual(p.litellm_kwargs.get("timeout"), 120)
+        self.assertIs(p.litellm_kwargs.get("drop_params"), True)
+
+    def test_skips_openai_client_setup(self):
+        # Parent OpenAICompatProvider sets self.client; we deliberately don't.
+        p = LiteLLMProvider(model_id="openai/gpt-4o")
+        self.assertFalse(hasattr(p, "client"))
+
+
+# ---------------------------------------------------------------------------
+# chat() routing
+# ---------------------------------------------------------------------------
+
+
+class TestChatRouting(unittest.TestCase):
+    def test_chat_routes_through_litellm(self):
+        p = LiteLLMProvider(model_id="anthropic/claude-3-5-sonnet-20241022")
+        captured = {}
+
+        def fake_completion(**kwargs):
+            captured.update(kwargs)
+            return _completion_response("4")
+
+        with patch("litellm.completion", side_effect=fake_completion):
+            response_msg, usage = p.chat([_user("What is 2+2?")])
+
+        self.assertEqual(captured["model"], "anthropic/claude-3-5-sonnet-20241022")
+        self.assertIs(captured["drop_params"], True)
+        self.assertEqual(usage.input_tokens, 10)
+        self.assertEqual(usage.output_tokens, 5)
+        text_blocks = [b for b in response_msg.content if b.type == "text"]
+        self.assertEqual(len(text_blocks), 1)
+        self.assertEqual(text_blocks[0].text, "4")
+
+    def test_chat_forwards_credentials(self):
+        p = LiteLLMProvider(
+            model_id="anthropic/claude-3-5-sonnet-20241022",
+            api_key="sk-test",
+            base_url="https://example.invalid/v1",
+        )
+        captured = {}
+
+        def fake_completion(**kwargs):
+            captured.update(kwargs)
+            return _completion_response("ok")
+
+        with patch("litellm.completion", side_effect=fake_completion):
+            p.chat([_user("hi")])
+
+        self.assertEqual(captured["api_key"], "sk-test")
+        self.assertEqual(captured["api_base"], "https://example.invalid/v1")
+
+    def test_chat_no_credentials_omits_keys(self):
+        p = LiteLLMProvider(model_id="anthropic/claude-3-5-sonnet-20241022")
+        captured = {}
+
+        def fake_completion(**kwargs):
+            captured.update(kwargs)
+            return _completion_response("ok")
+
+        with patch("litellm.completion", side_effect=fake_completion):
+            p.chat([_user("hi")])
+
+        self.assertNotIn("api_key", captured)
+        self.assertNotIn("api_base", captured)
+
+    def test_chat_forwards_tools(self):
+        p = LiteLLMProvider(model_id="anthropic/claude-3-5-sonnet-20241022")
+        tool = ToolSpec(
+            name="get_weather",
+            description="Get weather",
+            input_schema={
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        )
+        captured = {}
+
+        def fake_completion(**kwargs):
+            captured.update(kwargs)
+            return _completion_response("call the tool")
+
+        with patch("litellm.completion", side_effect=fake_completion):
+            p.chat([_user("weather?")], tools=[tool])
+
+        self.assertEqual(len(captured["tools"]), 1)
+        self.assertEqual(captured["tools"][0]["function"]["name"], "get_weather")
+
+    def test_chat_propagates_tool_calls(self):
+        p = LiteLLMProvider(model_id="anthropic/claude-3-5-sonnet-20241022")
+        tool_call = SimpleNamespace(
+            id="call_123",
+            function=SimpleNamespace(
+                name="get_weather", arguments='{"city":"Tokyo"}'
+            ),
+        )
+
+        with patch(
+            "litellm.completion",
+            return_value=_completion_response("", tool_calls=[tool_call]),
+        ):
+            response_msg, _ = p.chat([_user("weather?")])
+
+        tool_uses = [b for b in response_msg.content if b.type == "tool_use"]
+        self.assertEqual(len(tool_uses), 1)
+        self.assertEqual(tool_uses[0].name, "get_weather")
+        self.assertEqual(tool_uses[0].input, {"city": "Tokyo"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                         
                                                                                                                                                                                                                     
  Adds LiteLLM as an opt-in second provider alongside the existing `OpenAICompatProvider`. Set `provider: "litellm"` in your `config.yaml` model block to skip the OpenAI-compatible base_url path (OpenRouter, vLLM,
   a self-hosted LiteLLM proxy) and call providers directly through the embedded `litellm` SDK. Same `chat(messages, tools)` interface, so the runner / agent loop / batch script are untouched.
                                                                                                                                                                                                                     
  ```yaml         
  model:
    provider: litellm                                                                                                                                                                                                
    model_id: anthropic/claude-3-5-sonnet-20241022
    # api_key / base_url optional. LiteLLM resolves provider keys from                                                                                                                                               
    # ANTHROPIC_API_KEY / OPENAI_API_KEY / AWS_ACCESS_KEY_ID / AZURE_API_KEY / etc.                                                                                                                                  
    litellm_kwargs:                                                                                                                                                                                                  
      drop_params: true   # default; silently strips kwargs the upstream rejects                                                                                                                                     
      num_retries: 5                                                                                                                                                                                                 
  ```
                                                                                                                                                                                                                     
  Default behaviour is unchanged: provider defaults to "openai_compat" and every existing config keeps routing through OpenRouter as before.                                                                         
                  
  ## Why                                                                                                                                                                                                                
                  
  - One provider entry, 100+ upstream backends (Anthropic, Vertex AI, Bedrock, Azure, Groq, Mistral, Ollama, ...) without running an extra OpenAI-compatible proxy.                                                  
  - Per-provider env vars resolved automatically. Eval against Anthropic Sonnet by setting ANTHROPIC_API_KEY and model_id: anthropic/claude-3-5-sonnet-20241022. Switch to Bedrock by changing the model prefix;
  nothing else moves.                                                                                                                                                                                                
  - drop_params=True (default) strips kwargs the upstream rejects (presence_penalty on Anthropic, response_format on Bedrock, etc.) instead of failing with UnsupportedParamsError.
                                                                                                                                                                                                                     
  ## Files                                                                                                                                                                                                              
                                                                                                                                                                                                                     
  - src/claw_eval/runner/providers/litellm.py (new, 146 LOC). Standalone LiteLLMProvider with the same chat() signature as OpenAICompatProvider. Reuses the existing module-level helpers in openai_compat.py        
  (_message_to_openai, _tool_spec_to_openai, _extract_text_tool_calls); has its own _parse_response since it is not a subclass.
  - src/claw_eval/runner/providers/__init__.py. Adds make_provider(model_cfg) factory that dispatches on model_cfg.provider and raises on unknowns.                                                                  
  - src/claw_eval/config.py. Adds provider: str = "openai_compat" and litellm_kwargs: dict | None = None fields to ModelConfig.                                                                                      
  - src/claw_eval/cli.py. Replaces 4 direct OpenAICompatProvider(...) call sites with a small _make_model_provider(cfg, model_id, api_key, base_url) helper that mirrors the existing _make_judge(cfg, args) pattern.
  - pyproject.toml. New optional extra: litellm = ["litellm>=1.60,<1.85"].                                                                                                                                           
  - tests/test_litellm_provider.py (new). 13 unit tests covering factory dispatch, init defaults, kwargs merging, chat routing, credential forwarding, tool passthrough, and tool-call propagation.                  
  - README.md. New "LiteLLM provider (optional)" section under Quick Start.                                                                                                                                          
                                                                                                                                                                                                                     
  OpenAICompatProvider itself is unchanged.                                                                                                                                                                          
                                                                                                                                                                                                                     
  ## Tests                                                                                                                                                                                                              

 ```bash                 
  $ ruff check src/claw_eval/runner/providers/litellm.py \
              src/claw_eval/runner/providers/__init__.py \                                                                                                                                                           
              tests/test_litellm_provider.py \
              --select=E,F,I --line-length=120                                                                                                                                                                       
  All checks passed!                                                                                                                                                                                                 
                                                                                                                                                                                                                     
  $ ruff format --check --line-length=120 \                                                                                                                                                                          
              src/claw_eval/runner/providers/litellm.py \                                                                                                                                                            
              src/claw_eval/runner/providers/__init__.py \
              tests/test_litellm_provider.py                                                                                                                                                                         
  ============================== 13 passed in 1.15s ==============================

  Live E2E (Anthropic Claude Sonnet 4-6 via Azure AI Foundry)

  === chat() :: anthropic/claude-sonnet-4-6 ===
    text         : '4'
    in/out tokens: 20/5
    PASS

  === drop_params=True default :: presence_penalty=0.5 ===
    text       : '4'        ← Anthropic accepted; presence_penalty silently dropped
    PASS

  === tools=[get_weather] :: anthropic/claude-sonnet-4-6 ===
    tool_use   : get_weather({'city': 'Tokyo'})
    PASS
```

  ## CLI smoke
```bash
  $ claw-eval --help
  usage: claw-eval [-h] {run,_run-inner,build-image,grade,batch,cleanup,list} ...

  $ python -c "from claw_eval.config import load_config; \
               cfg = load_config('config_general.yaml'); \
               print(cfg.model.provider, cfg.model.model_id)"
  openai_compat anthropic/claude-opus-4.6
```
  Existing config_general.yaml parses unchanged with the new provider field defaulting to "openai_compat".

 ##  Reproduce
```bash
  pip install -e ".[litellm,dev]"
  export ANTHROPIC_API_KEY=sk-ant-...
  pytest tests/test_litellm_provider.py
```
```python
  import asyncio
  from claw_eval.config import ModelConfig
  from claw_eval.models.content import TextBlock
  from claw_eval.models.message import Message
  from claw_eval.runner.providers import make_provider

  cfg = ModelConfig(provider='litellm', model_id='anthropic/claude-3-5-sonnet-20241022')
  p = make_provider(cfg)
  out, usage = p.chat([Message(role='user', content=[TextBlock(text='2+2?')])])
  print(out.content[0].text, usage.total_tokens)
 ```
