### PR TITLE
Validate required fixture fields on every row

### DIFF
--- a/scripts/validate_tasks.py
+++ b/scripts/validate_tasks.py
@@ -157,17 +157,24 @@ class TaskValidator:
                     self.warnings.append(f"fixture {fixture_path_str}: empty array")
                     continue
 
-                # Check required fields
+                # Check required fields on every fixture row, not just the
+                # first one. Later rows can be generated or edited separately.
                 svc_name = svc.name
                 if svc_name in FIXTURE_REQUIRED_FIELDS:
                     required = FIXTURE_REQUIRED_FIELDS[svc_name]
-                    first_item = data[0]
-                    for field in required:
-                        if field not in first_item:
+                    for index, item in enumerate(data):
+                        if not isinstance(item, dict):
                             self.errors.append(
-                                f"fixture {fixture_path_str}: missing required field '{field}' "
-                                f"(expected for {svc_name})"
+                                f"fixture {fixture_path_str}[{index}]: expected object, "
+                                f"got {type(item).__name__}"
                             )
+                            continue
+                        for field in required:
+                            if field not in item:
+                                self.errors.append(
+                                    f"fixture {fixture_path_str}[{index}]: missing required field "
+                                    f"'{field}' (expected for {svc_name})"
+                                )
 
     def _check_tool_endpoints(self):
         task = self.task

--- a/tests/test_validate_tasks.py
+++ b/tests/test_validate_tasks.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "validate_tasks.py"
+
+spec = importlib.util.spec_from_file_location("validate_tasks", SCRIPT_PATH)
+validate_tasks = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = validate_tasks
+spec.loader.exec_module(validate_tasks)
+
+
+class ValidateTasksFixtureTests(unittest.TestCase):
+    def test_fixture_required_fields_are_checked_for_every_row(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            project_root = Path(tmp)
+            task_dir = project_root / "tasks" / "T_fixture_schema"
+            fixture_dir = project_root / "fixtures" / "gmail"
+            task_dir.mkdir(parents=True)
+            fixture_dir.mkdir(parents=True)
+
+            (task_dir / "task.yaml").write_text(
+                textwrap.dedent(
+                    """
+                    task_id: T_fixture_schema
+                    task_name: Fixture schema validation
+                    version: "1.0"
+                    prompt:
+                      text: Check fixture schema.
+                      language: en
+                    services:
+                      - name: gmail
+                        command: python mock_services/gmail/server.py
+                        port: 9100
+                        health_check: http://localhost:9100/gmail/messages
+                        reset_endpoint: http://localhost:9100/gmail/reset
+                        env:
+                          GMAIL_FIXTURES: fixtures/gmail/messages.json
+                    tools: []
+                    tool_endpoints: []
+                    scoring_components:
+                      - name: done
+                        weight: 1.0
+                        check:
+                          type: keywords_present
+                          keywords: [done]
+                    safety_checks: []
+                    """
+                ).lstrip(),
+                encoding="utf-8",
+            )
+            (task_dir / "grader.py").write_text(
+                textwrap.dedent(
+                    """
+                    from claw_eval.graders.base import AbstractGrader
+
+
+                    class DemoGrader(AbstractGrader):
+                        def grade(self, messages, dispatches, task, **kwargs):
+                            return {}
+                    """
+                ).lstrip(),
+                encoding="utf-8",
+            )
+            (fixture_dir / "messages.json").write_text(
+                json.dumps(
+                    [
+                        {
+                            "message_id": "m1",
+                            "from": "a@example.com",
+                            "subject": "Complete",
+                            "date": "2026-05-10",
+                            "body": "ok",
+                        },
+                        {
+                            "message_id": "m2",
+                            "from": "b@example.com",
+                            "subject": "Missing body",
+                            "date": "2026-05-10",
+                        },
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            original_project_root = validate_tasks.PROJECT_ROOT
+            validate_tasks.PROJECT_ROOT = project_root
+            try:
+                validator = validate_tasks.TaskValidator(task_dir)
+                self.assertFalse(validator.validate())
+            finally:
+                validate_tasks.PROJECT_ROOT = original_project_root
+
+            self.assertIn(
+                "fixture fixtures/gmail/messages.json[1]: missing required field "
+                "'body' (expected for gmail)",
+                validator.errors,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR makes `scripts/validate_tasks.py` validate required fixture fields on every row of each JSON fixture array.

Changes:

- check each fixture item instead of only `data[0]`
- report the row index when a required field is missing
- report a clear error if a fixture array contains a non-object item
- add an offline regression test that catches a second Gmail fixture row missing `body`

## Why

The task validator is meant to catch task and fixture integrity issues before benchmark runs. The current required-field check only inspects the first fixture item, so a later malformed record can silently pass validation as long as the first record is complete.

That can hide fixture drift in multi-record datasets and make task failures harder to reproduce.

## Validation

From the repo root:

```bash
python3 -m py_compile scripts/validate_tasks.py tests/test_validate_tasks.py
python3 -m unittest tests/test_validate_tasks.py
python3 scripts/validate_tasks.py --pattern 'T024*'
git diff --check
```

The targeted unittest builds a temporary task with two Gmail fixture rows and verifies that the validator reports the second row when `body` is missing.

## Scope / limits

This PR does not change task data, required-field definitions, service logic, or scoring behavior. It only makes the existing fixture schema check cover every row and adds a regression test for that behavior.
