### PR TITLE
fix: accept start_date/end_date in calendar_list_events to match task.yaml schema

### DIFF
--- a/mock_services/calendar/server.py
+++ b/mock_services/calendar/server.py
@@ -84,8 +84,30 @@ def _log_call(endpoint: str, request_body: dict[str, Any], response_body: Any) -
 
 
 class ListEventsRequest(BaseModel):
-    date: str
+    # Canonical schema: single date + day count
+    date: str | None = None
     days: int = 1
+    # Alias schema used by several task.yaml tool definitions (see commit 39b27dc).
+    # Either {date, days} or {start_date[, end_date]} is accepted.
+    start_date: str | None = None
+    end_date: str | None = None
+
+    def resolved(self) -> tuple[str, int]:
+        """Return (date, days) honoring both schemas. Raises ValueError if neither given."""
+        if self.date:
+            return self.date, max(1, self.days)
+        if self.start_date:
+            if self.end_date:
+                try:
+                    s = datetime.strptime(self.start_date, "%Y-%m-%d")
+                    e = datetime.strptime(self.end_date, "%Y-%m-%d")
+                    days = max(1, (e - s).days + 1)
+                except ValueError:
+                    days = max(1, self.days)
+            else:
+                days = max(1, self.days)
+            return self.start_date, days
+        raise ValueError("Either 'date' or 'start_date' must be provided")
 
 
 class GetEventRequest(BaseModel):
@@ -114,13 +136,19 @@ def list_events(req: ListEventsRequest | None = None) -> dict[str, Any]:
     if req is None:
         req = ListEventsRequest(date="2026-03-02")
     try:
-        query_date = datetime.strptime(req.date, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        date_str, days = req.resolved()
+    except ValueError as exc:
+        resp = {"error": str(exc)}
+        _log_call("/calendar/events", req.model_dump(exclude_none=True), resp)
+        return resp
+    try:
+        query_date = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
     except ValueError:
-        resp = {"error": f"Invalid date format: {req.date}"}
-        _log_call("/calendar/events", req.model_dump(), resp)
+        resp = {"error": f"Invalid date format: {date_str}"}
+        _log_call("/calendar/events", req.model_dump(exclude_none=True), resp)
         return resp
 
-    end_date = query_date + timedelta(days=req.days)
+    end_date = query_date + timedelta(days=days)
     results = []
     for evt in _events:
         evt_start = datetime.fromisoformat(evt["start_time"].replace("Z", "+00:00"))


### PR DESCRIPTION
## Summary

12 calendar-related tasks (T113/T114 meeting_preparation, T123/T124 todo_calendar_conflict, T129/T130 business_trip_planning, T135/T136 weekly_meeting_tracking, T149/T150 project_progress_report, T155/T156 onsite_support_dispatch) have been **silently broken since commit 39b27dc** ("fix datetime for calendar", 2026-05-08).

Those task.yaml files declare the `calendar_list_events` tool with the schema:
```yaml
input_schema:
  properties:
    start_date: {type: string}
    end_date:   {type: string}
  required: []
```

…but `mock_services/calendar/server.py:86` only accepts:
```python
class ListEventsRequest(BaseModel):
    date: str
    days: int = 1
```

so every call from those 12 tasks gets rejected with `422 Field required: body.date`. Reference solutions in those task.yaml files use `start_date=...` too (e.g. `T114_meeting_preparation/task.yaml:148`), confirming the schema was intentionally changed but the server was not updated alongside.

## Reproduce on main

```bash
$ curl -sX POST localhost:9101/calendar/events -H 'Content-Type: application/json' \
       -d '{"start_date":"2026-03-27","end_date":"2026-03-27"}'
{"detail":[{"type":"missing","loc":["body","date"],"msg":"Field required",
            "input":{"start_date":"2026-03-27","end_date":"2026-03-27"}}]}
```

## Impact — confirmed across 3 model evals

I ran the affected tasks on EXAONE-4.5-33B, DeepSeek-V4-Flash, and Claude-Sonnet-4.6 (3 trials each, official protocol). Out of **9 trials × 12 tasks = 108 model trials**, only **1** passed — DeepSeek stumbled onto `{"date":"..."}` by trial-and-error despite the schema not advertising it. EXAONE/Sonnet kept retrying `start_date`/`end_date` variants, then fell back to Bash, then gave up.

Trace evidence (Claude Sonnet 4.6 on T114, trial 0):
```
[2] tool_use calendar_list_events {start_date: 2026-03-27, end_date: 2026-03-27}
[4] tool_result {"detail":[{"type":"missing","loc":["body","date"],...}]}
[5] tool_use calendar_list_events {}
[7] tool_result {"detail":[{"type":"missing","loc":["body","date"],...}]}
[11] tool_use calendar_list_events {start_date: 2026-03-27}
[13] tool_result {"detail":[{"type":"missing","loc":["body","date"],...}]}
[14] tool_use calendar_list_events {end_date: 2026-03-27}
[16] tool_result {"detail":[{"type":"missing","loc":["body","date"],...}]}
[17] tool_use calendar_list_events {start_date: 2026-03-26, end_date: 2026-03-28}
[19] tool_result {"detail":[{"type":"missing","loc":["body","date"],...}]}
[20] assistant: "The calendar API appears to be returning a server-side validation
                 error regardless of input — it's expecting a `date` body field that
                 isn't part of the documented schema."
```

## Fix

Accept either schema. `{date, days}` stays canonical; `{start_date[, end_date]}` is resolved to a date range (`end_date - start_date + 1` days). The 6 task.yaml files that already use `{date, days}` continue to work unchanged.

## Tests

```
date+days           -> 4 events  (unchanged)
start_date+end_date -> 4 events  (was: 422 error)
start_date only     -> 4 events  (was: 422 error)
empty body          -> {"error":"Either 'date' or 'start_date' must be provided"}
invalid date        -> {"error":"Invalid date format: ..."}
```

Verified against `tasks/T114_meeting_preparation/fixtures/calendar/events.json` with `MOCK_TODAY=2026-03-26`.

## Why this approach (server-side) vs alternative

Server-side fix touches 1 file and immediately unblocks all 12 broken tasks plus any future task.yaml schema variant. The alternative — reverting 12 task.yaml files back to `{date, days}` — would require updating each task's `reference_solution` text too (12 separate edits) and would discard whatever motivated commit 39b27dc in the first place.

## Test plan

- [ ] Spin up calendar mock service from this branch.
- [ ] Run any of T113/T114/T123/T124 etc. with a small model and confirm `calendar_list_events` calls succeed.
- [ ] Run the existing 6 tasks that use `{date, days}` (T003zh/T004 calendar_scheduling etc.) to confirm no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)