### PR TITLE
[codex] Track cached token usage in traces

### DIFF
--- a/src/claw_eval/models/trace.py
+++ b/src/claw_eval/models/trace.py
@@ -17,6 +17,9 @@ def _now() -> str:
 class TokenUsage(BaseModel):
     input_tokens: int = 0
     output_tokens: int = 0
+    cached_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    cache_read_input_tokens: int = 0
 
 
 class DimensionScores(BaseModel):
@@ -92,6 +95,9 @@ class TraceEnd(BaseModel):
     model_output_tokens: int = 0
     input_tokens: int = 0
     output_tokens: int = 0
+    cached_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    cache_read_input_tokens: int = 0
     total_tokens: int = 0
     model_time_s: float = 0.0
     tool_time_s: float = 0.0

--- a/src/claw_eval/runner/loop.py
+++ b/src/claw_eval/runner/loop.py
@@ -404,6 +404,9 @@ def run_task(
                 model_time_s += time.monotonic() - model_t0
                 total_usage.input_tokens += usage.input_tokens
                 total_usage.output_tokens += usage.output_tokens
+                total_usage.cached_input_tokens += usage.cached_input_tokens
+                total_usage.cache_creation_input_tokens += usage.cache_creation_input_tokens
+                total_usage.cache_read_input_tokens += usage.cache_read_input_tokens
                 turn_count += 1
 
                 # Log assistant message
@@ -558,6 +561,9 @@ def run_task(
             model_output_tokens=output_tok,
             input_tokens=input_tok,
             output_tokens=output_tok,
+            cached_input_tokens=total_usage.cached_input_tokens,
+            cache_creation_input_tokens=total_usage.cache_creation_input_tokens,
+            cache_read_input_tokens=total_usage.cache_read_input_tokens,
             total_tokens=total_tok,
             model_time_s=round(model_time_s, 2),
             tool_time_s=round(tool_time_s, 2),

--- a/src/claw_eval/runner/providers/openai_compat.py
+++ b/src/claw_eval/runner/providers/openai_compat.py
@@ -40,6 +40,41 @@ def _audio_format_from_mime(mime_type: str) -> str:
     return "wav"
 
 
+def _usage_value(obj: Any, key: str, default: Any = 0) -> Any:
+    """Read a usage field from SDK objects or plain dicts."""
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        value = obj.get(key, default)
+    else:
+        value = getattr(obj, key, default)
+    return value or default
+
+
+def _token_usage_from_response_usage(response_usage: Any) -> TokenUsage:
+    """Normalize provider usage payloads into trace token counters."""
+    if not response_usage:
+        return TokenUsage()
+
+    prompt_details = _usage_value(response_usage, "prompt_tokens_details", None)
+    cached_input_tokens = _usage_value(prompt_details, "cached_tokens")
+    cache_creation_input_tokens = _usage_value(response_usage, "cache_creation_input_tokens")
+    cache_read_input_tokens = _usage_value(response_usage, "cache_read_input_tokens")
+
+    # Anthropic-compatible endpoints expose cache reads separately from OpenAI's
+    # prompt_tokens_details.cached_tokens shape. Count them as cached input too.
+    if cache_read_input_tokens and not cached_input_tokens:
+        cached_input_tokens = cache_read_input_tokens
+
+    return TokenUsage(
+        input_tokens=_usage_value(response_usage, "prompt_tokens"),
+        output_tokens=_usage_value(response_usage, "completion_tokens"),
+        cached_input_tokens=cached_input_tokens,
+        cache_creation_input_tokens=cache_creation_input_tokens,
+        cache_read_input_tokens=cache_read_input_tokens,
+    )
+
+
 _TOOL_CALL_BLOCK_RE = re.compile(
     r"<tool_call>\s*(.*?)\s*</tool_call>",
     flags=re.IGNORECASE | re.DOTALL,
@@ -537,10 +572,7 @@ class OpenAICompatProvider:
 
         usage = TokenUsage()
         if response.usage:
-            usage = TokenUsage(
-                input_tokens=response.usage.prompt_tokens,
-                output_tokens=response.usage.completion_tokens,
-            )
+            usage = _token_usage_from_response_usage(response.usage)
 
         # Capture reasoning_content from thinking models (DeepSeek-R1, QwQ, etc.)
         # OpenRouter returns "reasoning" instead of "reasoning_content"

--- a/tests/runner/providers/test_openai_compat.py
+++ b/tests/runner/providers/test_openai_compat.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+
+from claw_eval.runner.providers.openai_compat import OpenAICompatProvider
+
+
+def _response_with_usage(usage):
+    message = SimpleNamespace(
+        content="done",
+        reasoning_content=None,
+        reasoning=None,
+        tool_calls=None,
+    )
+    choice = SimpleNamespace(message=message)
+    return SimpleNamespace(choices=[choice], usage=usage)
+
+
+def test_parse_response_preserves_openai_cached_tokens():
+    provider = OpenAICompatProvider()
+    response = _response_with_usage(
+        SimpleNamespace(
+            prompt_tokens=100,
+            completion_tokens=20,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=40),
+        )
+    )
+
+    _, usage = provider._parse_response(response)
+
+    assert usage.input_tokens == 100
+    assert usage.output_tokens == 20
+    assert usage.cached_input_tokens == 40
+    assert usage.cache_creation_input_tokens == 0
+    assert usage.cache_read_input_tokens == 0
+
+
+def test_parse_response_preserves_anthropic_cache_tokens():
+    provider = OpenAICompatProvider()
+    response = _response_with_usage(
+        SimpleNamespace(
+            prompt_tokens=100,
+            completion_tokens=20,
+            cache_creation_input_tokens=15,
+            cache_read_input_tokens=35,
+        )
+    )
+
+    _, usage = provider._parse_response(response)
+
+    assert usage.input_tokens == 100
+    assert usage.output_tokens == 20
+    assert usage.cached_input_tokens == 35
+    assert usage.cache_creation_input_tokens == 15
+    assert usage.cache_read_input_tokens == 35


### PR DESCRIPTION
## Summary
- add cached input, cache creation, and cache read counters to trace usage models
- normalize OpenAI-style prompt_tokens_details.cached_tokens and Anthropic-compatible cache read/write fields
- carry cache counters into trace_end summaries
- add focused provider parsing tests

## Why
Agent benchmark traces currently keep normal input/output token totals, but provider usage payloads can distinguish cached input and cache read/write tokens. Preserving those counters makes benchmark traces useful for cache-cost analysis without changing model requests or benchmark behavior.

## Validation
- .venv/bin/python -m pytest tests/runner/providers/test_openai_compat.py -q
- .venv/bin/python -m compileall -q src/claw_eval/runner/providers/openai_compat.py src/claw_eval/models/trace.py src/claw_eval/runner/loop.py
- git diff --check